### PR TITLE
Fix gui cuz marshmallow no longer use ModelSchema

### DIFF
--- a/roadrecon/roadtools/roadrecon/server.py
+++ b/roadrecon/roadtools/roadrecon/server.py
@@ -27,7 +27,7 @@ class RTModelConverter(ModelConverter):
     )
 
 # Our custom model schema which uses the model converter from above
-class RTModelSchema(ma.ModelSchema):
+class RTModelSchema(ma.SQLAlchemySchema):
     class Meta:
         model_converter = RTModelConverter
 


### PR DESCRIPTION
If you try to run `roadrecon gui` it returns an error:

```
❯ roadrecon gui                             
Traceback (most recent call last):
  File "/usr/local/bin/roadrecon", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/roadtools/roadrecon/main.py", line 90, in main
    from roadtools.roadrecon.server import main as servermain
  File "/usr/local/lib/python3.7/dist-packages/roadtools/roadrecon/server.py", line 30, in <module>
    class RTModelSchema(ma.ModelSchema):
AttributeError: 'Marshmallow' object has no attribute 'ModelSchema'
```

Marshmallow library no longer use ModelSchema, it has been replaced for SQLAlchemySchema as they posted [here](https://github.com/marshmallow-code/flask-marshmallow/blob/dev/CHANGELOG.rst#0120-2020-04-26)

Maybe an upgrade is needed with `pip install -U marshmallow marshmallow-sqlalchemy`.

Right now working with marshmallow-3.5.1 and marshmallow-sqlalchemy-0.23.0:

```
❯ roadrecon gui                                    
 * Serving Flask app "roadtools.roadrecon.server" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
127.0.0.1 - - [28/Apr/2020 07:44:44] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [28/Apr/2020 07:44:48] "GET /styles.8374e83ed272c730ca49.css HTTP/1.1" 200 -
127.0.0.1 - - [28/Apr/2020 07:44:48] "GET /polyfills-es2015.ca64e4516afbb1b890d5.js HTTP/1.1" 200 -
127.0.0.1 - - [28/Apr/2020 07:44:48] "GET /runtime-es2015.0811dcefd377500b5b1a.js HTTP/1.1" 200 -
127.0.0.1 - - [28/Apr/2020 07:44:48] "GET /main-es2015.5ccf207c91bfc0017e47.js HTTP/1.1" 200 -
127.0.0.1 - - [28/Apr/2020 07:44:52] "GET /assets/rt_logoonly_margin.svg HTTP/1.1" 200 -
127.0.0.1 - - [28/Apr/2020 07:44:52] "GET /robots.txt HTTP/1.1" 404 -

```